### PR TITLE
feat: improve error handling, observability and documentation for v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,66 @@
 # Changelog
 All notable changes to this plugin will be documented in this file.
 
+## [3.2.0] - 30/01/2026
+### Added
+- New `onError` callback in `Flourish.create()` for custom handling of web app ERROR events
+- `ErrorEvent.fromJson()` factory for parsing ERROR postMessage events from the web app
+- Structured logging via `dart:developer` `log()` across the entire SDK, filterable by `FlourishSDK` name in DevTools
+- `ERROR` case in JavaScript message handler — web app ERROR events now properly dispatched
+
+### Fixed
+- Bug where 403 error handling did not return early, potentially executing both 403 and network error handlers
+- `ErrorEvent` class was defined but never instantiated — now properly created for ERROR events
+- `onErrorEvent` listener was defined but never received events — now works as intended
+
+### Changed
+- ERROR events from web app now create `ErrorEvent` (with `code` and `message`) instead of `GenericEvent`
+- Replaced all `print()` calls with `dart:developer` `log()` for production-safe, structured logging
+  - SDK logs use `name: 'FlourishSDK'` — filter in DevTools to see only SDK logs
+  - Error logs use `level: 1000`, warnings use `level: 900`, info uses default level
+  - Error objects passed via `error` parameter for structured inspection in DevTools
+
+### Error Scenarios Reference
+
+#### Native WebView Errors (`handleLoadingPageError`)
+| Error | Cause | Page |
+|-------|-------|------|
+| `errorCode == 403` | CloudFront access denied / token error | `FlourishTokenErrorPage` |
+| `WebResourceErrorType.connect` | TCP connection failed | `WebViewLoadErrorPage` |
+| `WebResourceErrorType.timeout` | Request timed out (common in high-latency regions) | `WebViewLoadErrorPage` |
+| `WebResourceErrorType.hostLookup` | DNS resolution failed | `WebViewLoadErrorPage` |
+| `errorCode == -1009` | iOS: no internet connection | `WebViewLoadErrorPage` |
+
+#### Web App Errors (JavaScript postMessage)
+| Event | Cause | Default Behavior |
+|-------|-------|-----------------|
+| `INVALID_TOKEN` | 401 auth failure | `AuthErrorPage` or custom `onAuthError` |
+| `ERROR` | Network, business logic (422), onboarding, maintenance errors | `FlourishTokenErrorPage` or custom `onError` |
+| `ERROR_BACK_BUTTON_PRESSED` | User pressed back on error page | `GenericEvent` dispatched |
+
+### Migration Guide
+No migration required. To add custom error handling:
+
+```dart
+import 'dart:developer' as developer;
+
+final flourish = await Flourish.create(
+  uuid: uuid,
+  secret: secret,
+  env: Environment.production,
+  language: Language.spanish,
+  customerCode: customerCode,
+  onError: (context, errorEvent) {
+    developer.log('Error: ${errorEvent.code} - ${errorEvent.message}', name: 'MyApp', level: 1000);
+  },
+);
+
+// Or via stream listener
+flourish.onErrorEvent((ErrorEvent event) {
+  developer.log('Error: ${event.code} - ${event.message}', name: 'MyApp', level: 1000);
+});
+```
+
 ## [3.0.0] - 20/06/2025
 ### Changed
 - **BREAKING**: Refactored Language enum to use getter instead of nullable method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 All notable changes to this plugin will be documented in this file.
 
-## [3.2.0] - 30/01/2026
+## [4.0.0] - 30/01/2026
+### Breaking Changes
+- `ErrorEvent` now uses named arguments: `ErrorEvent({required code, message})` (was positional `ErrorEvent(code, message)`)
+- `ErrorEvent.name` changed from `'ErrorEvent'` to `'ERROR'` (`Event.ERROR`)
+
 ### Added
 - New `onError` callback in `Flourish.create()` for custom handling of web app ERROR events
 - `ErrorEvent.fromJson()` factory for parsing ERROR postMessage events from the web app
@@ -19,6 +23,7 @@ All notable changes to this plugin will be documented in this file.
   - SDK logs use `name: 'FlourishSDK'` — filter in DevTools to see only SDK logs
   - Error logs use `level: 1000`, warnings use `level: 900`, info uses default level
   - Error objects passed via `error` parameter for structured inspection in DevTools
+  - The auth token query param is redacted in URL logs, and JS messages log only the event name (no raw payload) to avoid leaking secrets/PII in production logs
 
 ### Error Scenarios Reference
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,273 @@
+[<img width="400" src="https://github.com/Flourish-savings/flourish-sdk-flutter/blob/main/images/logo_flourish.png?raw=true"/>](https://flourishfi.com)
+<br>
+<br>
+# Flourish SDK Flutter
+
+Este plugin de Flutter permite la comunicaci&oacute;n entre la implementaci&oacute;n visual de las funcionalidades de Flourish.
+<br>
+<br>
+
+Tabla de contenidos
+=================
+
+<!--ts-->
+   * [Primeros Pasos](#primeros-pasos)
+     * [Sobre el SDK](#sobre-el-sdk)
+     * [Uso del SDK](#uso-del-sdk)
+   * [Eventos](#eventos)
+   * [Manejo de Errores](#manejo-de-errores)
+   * [Ejemplos](#ejemplos)
+<!--te-->
+<br>
+
+## Primeros Pasos
+___
+
+### Agregar Flourish a tu proyecto
+
+En el archivo `pubspec.yaml` de tu proyecto, agrega la &uacute;ltima versi&oacute;n del SDK de Flourish Flutter a tus dependencias.
+```yaml
+# pubspec.yaml
+
+dependencies:
+  flourish_flutter_sdk: ^<latest version>
+```
+
+### Requisitos internos del SDK
+
+Para utilizar este SDK, necesitar&aacute;s los siguientes elementos:
+
+- uuid: un identificador &uacute;nico que ser&aacute; proporcionado por Flourish
+- secret: una cadena que representa una clave, tambi&eacute;n proporcionada por Flourish
+- customer_code: una cadena que representa un identificador de ti mismo
+
+Este plugin puede ejecutarse en dos entornos diferentes:
+
+- staging: En este entorno, puedes probar las funcionalidades sin impactar datos reales
+- production: este entorno es para ejecutar la aplicaci&oacute;n con datos reales
+<br>
+<br>
+
+### Sobre el SDK
+
+La integraci&oacute;n con nosotros funciona de la siguiente manera: el cliente se autentica en nuestro backend
+y le devolvemos un token de acceso que le permite cargar nuestra webview. Dado esto,
+el SDK sirve para encapsular y ayudar en la carga de esta webview.
+
+### Uso del SDK
+___
+
+### 1 - Inicializaci&oacute;n
+
+##<span style="color:red;">IMPORTANTE&#10071;</span>
+
+
+<div style="border: 1px solid grey; padding: 10px;">
+
+**Para que el flujo funcione correctamente y para que tengamos las m&eacute;tricas correctas para demostrar nuestro valor, es extremadamente importante inicializar nuestro SDK al abrir tu App, por ejemplo al inicio o en la pantalla principal. Lo m&aacute;s importante es que no se inicialice al mismo tiempo que se abre nuestro m&oacute;dulo.**
+
+</div>
+
+___
+
+En primer lugar, es necesario inicializar el SDK proporcionando las variables: `uuid`, `secret`, `env`, `language` y `customerCode`.
+
+```dart
+    Flourish flourish = await Flourish.create(
+      uuid: 'AQUI_USARAS_TU_PARTNER_ID',
+      secret: 'AQUI_USARAS_TU_SECRET',
+      env: Environment.staging,
+      language: Language.spanish,
+      customerCode: 'AQUI_USARAS_TU_CUSTOMER_CODE',
+      trackingId: 'AQUI_USARAS_TU_CLAVE_DE_GOOGLE_ANALYTICS_ESTO_NO_ES_OBLIGATORIO',
+      onError: (context, errorEvent) {
+        // Se ejecuta cuando la web app env&iacute;a un evento ERROR (errores de red, l&oacute;gica de negocio, mantenimiento)
+        developer.log('Error: ${errorEvent.code} - ${errorEvent.message}', name: 'MyApp', level: 1000);
+      },
+      onAuthError: (context) {
+        // Se ejecuta cuando la web app env&iacute;a un evento INVALID_TOKEN (fallo de autenticaci&oacute;n 401)
+        // Usa esto para refrescar el token o redirigir al login
+      },
+      onWebViewLoadError: (context, error) {
+        // Se ejecuta cuando el WebView no puede cargar (sin internet, fallo DNS, timeout)
+        // Usa esto para mostrar una pantalla de error nativa personalizada
+      },
+    );
+```
+
+La variable `trackingId` se usa si deseas pasar tu clave de Google Analytics para poder monitorear el uso de nuestra plataforma por parte de tus usuarios.
+
+Los callbacks de error (`onError`, `onAuthError`, `onWebViewLoadError`) son todos opcionales. Si no se proporcionan, el SDK muestra p&aacute;ginas de error predeterminadas. Consulta [Manejo de Errores](#manejo-de-errores) para m&aacute;s detalles.
+
+### 2 - Abrir el m&oacute;dulo Flourish
+
+Finalmente debemos llamar al m&eacute;todo `home()`.
+```dart
+  flourish.home();
+```
+
+## EVENTOS
+___
+
+Tambi&eacute;n puedes registrarte para recibir algunos eventos y saber cu&aacute;ndo algo ocurre dentro de nuestra plataforma.
+
+Puedes escuchar un evento espec&iacute;fico ya mapeado, un evento no mapeado, o todos los eventos si lo prefieres.
+
+### Escuchar nuestros eventos mapeados
+
+Tenemos algunos eventos ya mapeados que puedes escuchar por separado.
+
+Por ejemplo, si necesitas saber cu&aacute;ndo nuestra funcionalidad de Trivia termin&oacute;, puedes escuchar el "TriviaGameFinishedEvent"
+
+```dart
+flourish.onTriviaGameFinishedEvent((TriviaGameFinishedEvent response) {
+  developer.log("${response.name} - data: ${jsonEncode(response.data.toJson())}", name: 'MyApp');
+});
+```
+puedes encontrar todos nuestros eventos mapeados aqu&iacute;:
+https://github.com/Flourish-savings/flourish-sdk-flutter/tree/main/lib/events/types/v2
+
+### Escuchar nuestros eventos no mapeados
+Incluso si nuestra plataforma comienza a enviar nuevos eventos no mapeados, no ser&aacute; necesario actualizar la versi&oacute;n del SDK para consumirlos.
+
+Simplemente comienza a escuchar los eventos gen&eacute;ricos
+
+```dart
+flourish.onGenericEvent((GenericEvent response) {
+  developer.log("${response.name} - data: ${jsonEncode(response.data?.toJson())}", name: 'MyApp');
+});
+```
+
+### Escuchar todos los eventos
+Pero si quieres escuchar todos los eventos, tambi&eacute;n tenemos eso para ti.
+
+```dart
+flourish.onAllEvent((Event response) {
+  developer.log("Event: ${response.name}", name: 'MyApp');
+});
+```
+
+### Eventos disponibles
+aqu&iacute; tienes todos los eventos que retornaremos
+
+| Nombre del evento              | Descripci&oacute;n                                                                                                                   |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| BACK_BUTTON_PRESSED            | Cuando necesitas saber cu&aacute;ndo el usuario hace clic en el bot&oacute;n de retroceso del men&uacute; en nuestra plataforma.                       |
+| ERROR_BACK_BUTTON_PRESSED      | Cuando necesitas saber cu&aacute;ndo el usuario hace clic en el bot&oacute;n de retroceso del men&uacute; en nuestra p&aacute;gina de error.                   |
+| HOME_BACK_BUTTON_PRESSED       | Cuando necesitas saber cu&aacute;ndo el usuario hace clic en el bot&oacute;n de retroceso estando en la pantalla principal de nuestra plataforma. |
+| ONBOARDING_BACK_BUTTON_PRESSED | Cuando necesitas saber cu&aacute;ndo el usuario hace clic en el bot&oacute;n de retroceso estando en la pantalla de onboarding.               |
+| TERMS_ACCEPTED                 | Cuando necesitas saber cu&aacute;ndo el usuario acepta los t&eacute;rminos.                                                                  |
+| TRIVIA_GAME_FINISHED           | Cuando necesitas saber cu&aacute;ndo el usuario termina un juego de Trivia en nuestra plataforma.                                    |
+| TRIVIA_CLOSED                  | Cuando necesitas saber cu&aacute;ndo el usuario cerr&oacute; el juego de Trivia en nuestra plataforma.                                        |
+| REFERRAL_COPY                  | Cuando necesitas saber cu&aacute;ndo el usuario copia el c&oacute;digo de referido al portapapeles.                                           |
+| REFERRAL_FINISHED              | Cuando necesitas saber cu&aacute;ndo el referido finaliz&oacute;.                                                                            |
+| REFERRAL_REWARD_REDEEMED       | Cuando necesitas saber cu&aacute;ndo el usuario canjea las recompensas de referido.                                                  |
+| REFERRAL_REWARD_SKIPPED        | Cuando necesitas saber cu&aacute;ndo el usuario omiti&oacute; las recompensas de referido.                                                    |
+| GIFT_CARD_COPY                 | Cuando necesitas saber cu&aacute;ndo el usuario copia el c&oacute;digo de Gift Card al portapapeles.                                          |
+| HOME_BANNER_ACTION             | Cuando necesitas saber cu&aacute;ndo el usuario hace clic en el banner principal.                                                    |
+| MISSION_ACTION                 | Cuando necesitas saber cu&aacute;ndo el usuario hace clic en una tarjeta de misi&oacute;n.                                                    |
+| AUTHENTICATION_FAILURE         | Cuando necesitas saber cu&aacute;ndo la autenticaci&oacute;n fall&oacute;.                                                                            |
+| ERROR                          | Cuando ocurre un error en la aplicaci&oacute;n web (red, l&oacute;gica de negocio, onboarding, mantenimiento).                               |
+| INVALID_TOKEN                  | Cuando el token de sesi&oacute;n es inv&aacute;lido o expir&oacute; (401). Se despacha antes de ERROR.                                                |
+
+## Manejo de Errores
+___
+
+El SDK maneja errores en dos niveles: **errores nativos del WebView** (antes de que la web app cargue) y **errores de la web app** (enviados v&iacute;a JavaScript postMessage despu&eacute;s de que la p&aacute;gina carga).
+
+### Errores Nativos del WebView
+
+Estos ocurren cuando el WebView no puede cargar la p&aacute;gina (ej: sin internet, fallo DNS, timeout). El SDK los detecta v&iacute;a `onWebResourceError` y muestra una p&aacute;gina predeterminada de "Sin conexi&oacute;n a internet".
+
+| Error | Causa | P&aacute;gina Predeterminada |
+|-------|-------|----------------------|
+| `WebResourceErrorType.connect` | Fallo de conexi&oacute;n TCP (servidor inalcanzable, puerto bloqueado) | `WebViewLoadErrorPage` |
+| `WebResourceErrorType.timeout` | Tiempo de espera agotado (com&uacute;n en regiones de alta latencia) | `WebViewLoadErrorPage` |
+| `WebResourceErrorType.hostLookup` | Fallo en resoluci&oacute;n DNS | `WebViewLoadErrorPage` |
+| C&oacute;digo de error `-1009` | iOS: dispositivo sin conexi&oacute;n a internet | `WebViewLoadErrorPage` |
+| C&oacute;digo de error `403` | Acceso denegado de CloudFront / URL firmada expirada | `FlourishTokenErrorPage` |
+
+Para proporcionar una UI personalizada para estos errores:
+
+```dart
+Flourish flourish = await Flourish.create(
+  // ...
+  onWebViewLoadError: (context, error) {
+    // error.errorCode, error.errorType, error.description est&aacute;n disponibles
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (context) => MiPaginaDeErrorPersonalizada()),
+    );
+  },
+);
+```
+
+### Errores de la Web App
+
+Estos ocurren despu&eacute;s de que el WebView carga la p&aacute;gina. La web app comunica errores al SDK v&iacute;a `postMessage` a trav&eacute;s del canal JavaScript.
+
+| Evento | Causa | Comportamiento Predeterminado |
+|--------|-------|------------------------------|
+| `INVALID_TOKEN` | Token expirado o inv&aacute;lido (HTTP 401) | Muestra `AuthErrorPage` (refresca el token autom&aacute;ticamente) |
+| `ERROR` | Error de red, error de l&oacute;gica de negocio (422), fallo de onboarding, fallo de datos de mantenimiento | Muestra `FlourishTokenErrorPage` |
+| `ERROR_BACK_BUTTON_PRESSED` | Usuario presion&oacute; retroceso en la p&aacute;gina de error | Despacha `GenericEvent` |
+
+**Importante:** `INVALID_TOKEN` se despacha **antes** de `ERROR` por la web app. Si manejas `INVALID_TOKEN` (ej: refrescando el token), el evento `ERROR` subsiguiente puede ignorarse de forma segura.
+
+Para manejar errores de la web app:
+
+```dart
+Flourish flourish = await Flourish.create(
+  // ...
+  onAuthError: (context) {
+    // Manejar INVALID_TOKEN: refrescar token y recargar, o redirigir al login
+  },
+  onError: (context, errorEvent) {
+    // Manejar ERROR: errorEvent.code y errorEvent.message contienen detalles
+    developer.log('Error: ${errorEvent.code} - ${errorEvent.message}', name: 'MyApp', level: 1000);
+  },
+);
+```
+
+Tambi&eacute;n puedes escuchar eventos de error v&iacute;a el stream:
+
+```dart
+flourish.onErrorEvent((ErrorEvent event) {
+  developer.log('Error: ${event.code} - ${event.message}', name: 'MyApp', level: 1000);
+});
+```
+
+### Logging de Depuraci&oacute;n
+
+El SDK usa `dart:developer` `log()` para logging estructurado y seguro para producci&oacute;n. Todos los logs del SDK usan el nombre `FlourishSDK`, lo que permite filtrar en Flutter DevTools.
+
+Para ver los logs del SDK en DevTools, filtra por `FlourishSDK` en la pesta&ntilde;a de Logging.
+
+Ejemplo de salida para un error de carga del WebView:
+```
+[FlourishSDK] WebView Load Error - code: -1009, type: WebResourceErrorType.hostLookup, description: net::ERR_NAME_NOT_RESOLVED, isForMainFrame: true
+```
+
+Niveles de log utilizados:
+- **Default** (info): Carga de URL, mensajes JS, inicio de sesi&oacute;n exitoso
+- **900** (warning): C&oacute;digo de referido faltante, errores de conectividad de red
+- **1000** (error): Errores de carga del WebView, fallos al refrescar token
+
+En tu propia app, usa `dart:developer` `log()` en lugar de `print()`:
+```dart
+import 'dart:developer' as developer;
+
+flourish.onErrorEvent((ErrorEvent event) {
+  developer.log(
+    'Error: ${event.code} - ${event.message}',
+    name: 'MyApp',
+    level: 1000,
+  );
+});
+```
+
+## Ejemplos
+Dentro de este repositorio, tienes una app de ejemplo para mostrar c&oacute;mo integrarte con nosotros:
+
+https://github.com/Flourish-savings/flourish-sdk-flutter/tree/main/example
+<br>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 <br>
 # Flourish SDK Flutter
 
+> **[Leer en Espa&ntilde;ol](README.es.md)**
+
 This flutter plugin will allow the communication between the visual implementation of Flourish functionality.
 <br>
 <br>
@@ -12,9 +14,10 @@ Table of contents
 
 <!--ts-->
    * [Getting Started](#getting-started)
-     * [About the SDK](#about-the-sdk) 
-     * [Using the SDK](#using-the-sdk) 
+     * [About the SDK](#about-the-sdk)
+     * [Using the SDK](#using-the-sdk)
    * [Events](#events)
+   * [Error Handling](#error-handling)
    * [Examples](#examples)
 <!--te-->
 <br>
@@ -78,11 +81,25 @@ First foremost, it is necessary to initialize the SDK providing the variables: `
       env: Environment.staging,
       language: Language.english,
       customerCode: 'HERE_YOU_WILL_USE_YOUR_CUSTOMER_CODE',
-      trackingId: 'HERE_YOU_WILL_USE_YOUR_GOOGLE_ANALYTICS_KEY_THIS_IS_NOT_REQUIRED'
+      trackingId: 'HERE_YOU_WILL_USE_YOUR_GOOGLE_ANALYTICS_KEY_THIS_IS_NOT_REQUIRED',
+      onError: (context, errorEvent) {
+        // Called when the web app sends an ERROR event (network, business logic, maintenance errors)
+        developer.log('Error: ${errorEvent.code} - ${errorEvent.message}', name: 'MyApp', level: 1000);
+      },
+      onAuthError: (context) {
+        // Called when the web app sends an INVALID_TOKEN event (401 auth failure)
+        // Use this to refresh the token or redirect to login
+      },
+      onWebViewLoadError: (context, error) {
+        // Called when the WebView fails to load (no internet, DNS failure, timeout)
+        // Use this to show a custom native error screen
+      },
     );
 ```
 
 The `trackingId` variable is used if you want to pass on your Google Analytics Key to be able to monitor the use of our platform by your users.
+
+The error callbacks (`onError`, `onAuthError`, `onWebViewLoadError`) are all optional. If not provided, the SDK shows default error pages. See [Error Handling](#error-handling) for details.
 
 ### 2 - Open Flourish module
 
@@ -104,10 +121,9 @@ We have some events already mapped that you can listen to separately
 
 For example, if you need know when ou Trivia feature finished, you can listen to the "TriviaGameFinishedEvent"
 
-```
+```dart
 flourish.onTriviaGameFinishedEvent((TriviaGameFinishedEvent response) {
- print("Event name: ${response.name}");
- print("Event data: ${jsonEncode(response.data.toJson())}");
+  developer.log("${response.name} - data: ${jsonEncode(response.data.toJson())}", name: 'MyApp');
 });
 ```
 you can find our all mapped events here:
@@ -118,19 +134,18 @@ Even if our platform starts sending new unmapped events, it will not be necessar
 
 Just start listening to the generic events
 
-```
+```dart
 flourish.onGenericEvent((GenericEvent response) {
-  print("Event name: ${response.name}");
-  print("Event data: ${jsonEncode(response.data.toJson())}");
+  developer.log("${response.name} - data: ${jsonEncode(response.data?.toJson())}", name: 'MyApp');
 });
 ```
 
 ### Listen all events
 But if you want to listen all the events, we also have that for you.
 
-```
+```dart
 flourish.onAllEvent((Event response) {
-  print("Event name: ${response.name}");
+  developer.log("Event: ${response.name}", name: 'MyApp');
 });
 ```
 
@@ -154,8 +169,104 @@ here you have all events we will return
 | HOME_BANNER_ACTION             | When you need to know when the user clicks on the home banner.                                                    |
 | MISSION_ACTION                 | When you need to know when the user clicks on a mission card.                                                     |
 | AUTHENTICATION_FAILURE         | When you need to know when the Authentication failed.                                                             |
-| ERROR                          | When you need to know when a not mapped error happened.                                                           |
+| ERROR                          | When an error occurs in the web application (network, business logic, onboarding, maintenance).                   |
+| INVALID_TOKEN                  | When the session token is invalid or expired (401). Dispatched before ERROR.                                      |
 
+## Error Handling
+___
+
+The SDK handles errors at two levels: **native WebView errors** (before the web app loads) and **web app errors** (sent via JavaScript postMessage after the page loads).
+
+### Native WebView Errors
+
+These occur when the WebView itself fails to load the page (e.g., no internet, DNS failure, timeout). The SDK detects these via `onWebResourceError` and shows a default "No internet connection" page.
+
+| Error | Cause | Default Page |
+|-------|-------|-------------|
+| `WebResourceErrorType.connect` | TCP connection failed (server unreachable, port blocked) | `WebViewLoadErrorPage` |
+| `WebResourceErrorType.timeout` | Request timed out (common in high-latency regions) | `WebViewLoadErrorPage` |
+| `WebResourceErrorType.hostLookup` | DNS resolution failed | `WebViewLoadErrorPage` |
+| Error code `-1009` | iOS: device has no internet connection | `WebViewLoadErrorPage` |
+| Error code `403` | CloudFront access denied / signed URL expired | `FlourishTokenErrorPage` |
+
+To provide a custom UI for these errors:
+
+```dart
+Flourish flourish = await Flourish.create(
+  // ...
+  onWebViewLoadError: (context, error) {
+    // error.errorCode, error.errorType, error.description are available
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (context) => MyCustomErrorPage()),
+    );
+  },
+);
+```
+
+### Web App Errors
+
+These occur after the WebView loads the page. The web app communicates errors back to the SDK via `postMessage` through the JavaScript channel.
+
+| Event | Cause | Default Behavior |
+|-------|-------|-----------------|
+| `INVALID_TOKEN` | Token expired or invalid (HTTP 401) | Shows `AuthErrorPage` (auto-refreshes token) |
+| `ERROR` | Network error, business logic error (422), onboarding failure, maintenance data failure | Shows `FlourishTokenErrorPage` |
+| `ERROR_BACK_BUTTON_PRESSED` | User pressed back on the error page | Dispatches `GenericEvent` |
+
+**Important:** `INVALID_TOKEN` is dispatched **before** `ERROR` by the web app. If you handle `INVALID_TOKEN` (e.g., refreshing the token), the subsequent `ERROR` event can be safely ignored.
+
+To handle web app errors:
+
+```dart
+Flourish flourish = await Flourish.create(
+  // ...
+  onAuthError: (context) {
+    // Handle INVALID_TOKEN: refresh token and reload, or redirect to login
+  },
+  onError: (context, errorEvent) {
+    // Handle ERROR: errorEvent.code and errorEvent.message contain details
+    developer.log('Error: ${errorEvent.code} - ${errorEvent.message}', name: 'MyApp', level: 1000);
+  },
+);
+```
+
+You can also listen to error events via the stream:
+
+```dart
+flourish.onErrorEvent((ErrorEvent event) {
+  developer.log('Error: ${event.code} - ${event.message}', name: 'MyApp', level: 1000);
+});
+```
+
+### Debug Logging
+
+The SDK uses `dart:developer` `log()` for structured, production-safe logging. All SDK logs use the name `FlourishSDK`, which allows filtering in Flutter DevTools.
+
+To view SDK logs in DevTools, filter by `FlourishSDK` in the Logging tab.
+
+Example output for a WebView load error:
+```
+[FlourishSDK] WebView Load Error - code: -1009, type: WebResourceErrorType.hostLookup, description: net::ERR_NAME_NOT_RESOLVED, isForMainFrame: true
+```
+
+Log levels used:
+- **Default** (info): URL loading, JS messages, sign-in success
+- **900** (warning): Missing referral code, network connectivity errors
+- **1000** (error): WebView load errors, token refresh failures
+
+In your own app, use `dart:developer` `log()` instead of `print()`:
+```dart
+import 'dart:developer' as developer;
+
+flourish.onErrorEvent((ErrorEvent event) {
+  developer.log(
+    'Error: ${event.code} - ${event.message}',
+    name: 'MyApp',
+    level: 1000,
+  );
+});
+```
 
 ## Examples
 Inside this repository, you have an example app to show how to integrate with us:

--- a/example/lib/home.dart
+++ b/example/lib/home.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
 import 'package:flourish_flutter_sdk/events/types/v2/back_button_pressed_event.dart';
 import 'package:flourish_flutter_sdk/events/types/v2/gift_card_copy_event.dart';
@@ -52,6 +53,30 @@ class _HomeState extends State<Home> {
       env: Environment.staging,
       language: Language.spanish,
       customerCode: widget.customerCode,
+      onError: (context, errorEvent) {
+        // Called when the web app sends an ERROR event
+        // (network, business logic, onboarding, maintenance errors)
+        developer.log(
+          'Web app error - code: ${errorEvent.code}, message: ${errorEvent.message}',
+          name: 'FlourishExample',
+          level: 1000,
+        );
+      },
+      onAuthError: (context) {
+        // Called when the web app sends an INVALID_TOKEN event (401)
+        // Use this to refresh the token or redirect to your login screen
+        developer.log('Auth error - token invalid or expired', name: 'FlourishExample', level: 1000);
+      },
+      onWebViewLoadError: (context, error) {
+        // Called when the WebView fails to load (no internet, DNS, timeout)
+        // error.errorCode, error.errorType, error.description are available
+        developer.log(
+          'WebView load error - code: ${error.errorCode}, '
+          'type: ${error.errorType}, description: ${error.description}',
+          name: 'FlourishExample',
+          level: 1000,
+        );
+      },
     );
     // Update the state with fetched data only if the screen is still mounted
     if (!mounted) return;
@@ -135,61 +160,51 @@ class _HomeState extends State<Home> {
   void subscribeToFlourishEvents(Flourish flourish) {
     _subscriptions.addAll([
       flourish.onErrorEvent((ErrorEvent response) {
-        print("Event name: ${response.name}");
+        developer.log("Error event - code: ${response.code}, message: ${response.message}", name: 'FlourishExample');
       }),
       flourish.onAllEvent((Event response) {
-        print("Event name: ${response.name}");
+        developer.log("Event: ${response.name}", name: 'FlourishExample');
       }),
       flourish.onGenericEvent((GenericEvent response) {
         if (response.name == Event.TRIVIA_GAME_FINISHED) {
-          print("Event name: ${response.name}");
-          print("Event data: ${jsonEncode(response.data?.toJson())}");
+          developer.log("${response.name} - data: ${jsonEncode(response.data?.toJson())}", name: 'FlourishExample');
         }
       }),
       flourish.onWebViewLoadedEvent((WebViewLoadedEvent response) {
-        print("Event name: ${response.name}");
+        developer.log("Event: ${response.name}", name: 'FlourishExample');
       }),
       flourish.onAutoPaymentEvent((AutoPaymentEvent response) {
-        print("Event name: ${response.name}");
+        developer.log("Event: ${response.name}", name: 'FlourishExample');
       }),
       flourish.onPaymentEvent((PaymentEvent response) {
-        print("Event name: ${response.name}");
+        developer.log("Event: ${response.name}", name: 'FlourishExample');
       }),
       flourish.onTriviaFinishedEvent((TriviaFinishedEvent response) {
-        print("Event name: ${response.name}");
-        print("Event data: ${jsonEncode(response.data.toJson())}");
+        developer.log("${response.name} - data: ${jsonEncode(response.data.toJson())}", name: 'FlourishExample');
       }),
       flourish.onBackEvent((BackEvent response) {
-        print("Event name: ${response.name}");
-        print("Event data: ${jsonEncode(response.data.toJson())}");
+        developer.log("${response.name} - data: ${jsonEncode(response.data.toJson())}", name: 'FlourishExample');
       }),
       flourish.onBackButtonPressedEvent((BackButtonPressedEvent response) {
-        print("Event name: ${response.name}");
-        print("Event data: ${jsonEncode(response.data.toJson())}");
+        developer.log("${response.name} - data: ${jsonEncode(response.data.toJson())}", name: 'FlourishExample');
       }),
       flourish.onTriviaGameFinishedEvent((TriviaGameFinishedEvent response) {
-        print("Event name: ${response.name}");
-        print("Event data: ${jsonEncode(response.data.toJson())}");
+        developer.log("${response.name} - data: ${jsonEncode(response.data.toJson())}", name: 'FlourishExample');
       }),
       flourish.onTriviaCloseEvent((TriviaCloseEvent response) {
-        print("Event name: ${response.name}");
-        print("Event data: ${jsonEncode(response.data.toJson())}");
+        developer.log("${response.name} - data: ${jsonEncode(response.data.toJson())}", name: 'FlourishExample');
       }),
       flourish.onReferralCopyEvent((ReferralCopyEvent response) {
-        print("Event name: ${response.name}");
-        print("Event data: ${jsonEncode(response.data.toJson())}");
+        developer.log("${response.name} - data: ${jsonEncode(response.data.toJson())}", name: 'FlourishExample');
       }),
       flourish.onGiftCardCopyEvent((GiftCardCopyEvent response) {
-        print("Event name: ${response.name}");
-        print("Event data: ${jsonEncode(response.data.toJson())}");
+        developer.log("${response.name} - data: ${jsonEncode(response.data.toJson())}", name: 'FlourishExample');
       }),
       flourish.onHomeBannerActionEvent((HomeBannerActionEvent response) {
-        print("Event name: ${response.name}");
-        print("Event data: ${jsonEncode(response.data.toJson())}");
+        developer.log("${response.name} - data: ${jsonEncode(response.data.toJson())}", name: 'FlourishExample');
       }),
       flourish.onMissionActionEvent((MissionActionEvent response) {
-        print("Event name: ${response.name}");
-        print("Event data: ${jsonEncode(response.data.toJson())}");
+        developer.log("${response.name} - data: ${jsonEncode(response.data.toJson())}", name: 'FlourishExample');
       }),
     ]);
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -111,7 +111,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.1"
+    version: "3.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -171,26 +171,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.1"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -392,10 +392,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -480,10 +480,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -549,5 +549,5 @@ packages:
     source: hosted
     version: "1.0.4"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/lib/config/configuration.dart
+++ b/lib/config/configuration.dart
@@ -1,3 +1,3 @@
 class SdkInfo {
-  static const String version = "3.1.0";
+  static const String version = "3.2.0";
 }

--- a/lib/config/configuration.dart
+++ b/lib/config/configuration.dart
@@ -1,3 +1,3 @@
 class SdkInfo {
-  static const String version = "3.2.0";
+  static const String version = "4.0.0";
 }

--- a/lib/events/event.dart
+++ b/lib/events/event.dart
@@ -39,6 +39,8 @@ class Event {
   /// When you need to know when the Authentication failed.
   static const String AUTHENTICATION_FAILURE = 'AUTHENTICATION_FAILURE';
   static const String SIGN_IN_FAILED = 'SIGN_IN_FAILED';
+  /// When an error occurs in the web application (network, business logic, maintenance, etc.)
+  static const String ERROR = 'ERROR';
 
   final String name;
 
@@ -71,6 +73,8 @@ class Event {
         return HomeBannerActionEvent.from(json);
       case MISSION_ACTION:
         return MissionActionEvent.from(json);
+      case ERROR:
+        return ErrorEvent.fromJson(json);
       default:
         return GenericEvent.from(json);
     }
@@ -80,5 +84,18 @@ class Event {
 class ErrorEvent extends Event {
   final String code;
   final String? message;
-  const ErrorEvent(this.code, this.message) : super(name: 'ErrorEvent');
+
+  const ErrorEvent({
+    required this.code,
+    this.message,
+  }) : super(name: Event.ERROR);
+
+  factory ErrorEvent.fromJson(Map<String, dynamic> json) {
+    final rawData = json['data'];
+    final data = rawData is Map<String, dynamic> ? rawData : <String, dynamic>{};
+    return ErrorEvent(
+      code: data['code']?.toString() ?? 'UNKNOWN_ERROR',
+      message: data['message']?.toString(),
+    );
+  }
 }

--- a/lib/events/event.dart
+++ b/lib/events/event.dart
@@ -73,6 +73,9 @@ class Event {
         return HomeBannerActionEvent.from(json);
       case MISSION_ACTION:
         return MissionActionEvent.from(json);
+      // The JS channel routes ERROR directly to handleWebAppError, so this
+      // case is not hit by that path; it is the fallback for any other caller
+      // that parses a raw ERROR payload through Event.fromJson.
       case ERROR:
         return ErrorEvent.fromJson(json);
       default:

--- a/lib/flourish.dart
+++ b/lib/flourish.dart
@@ -42,6 +42,14 @@ class Flourish {
   late bool reloadPageOnAppResume;
   void Function(BuildContext context, WebResourceError error)? onWebViewLoadError;
   void Function(BuildContext context)? onAuthError;
+
+  /// Called when the web app emits an [Event.ERROR].
+  ///
+  /// When provided, the integrator owns the error UI and the SDK's default
+  /// navigation to its generic error page is suppressed. Regardless of this
+  /// callback, the [ErrorEvent] is always published on the [onErrorEvent]
+  /// stream, so a stream subscription observes errors but does NOT suppress the
+  /// default navigation — use this callback for that.
   void Function(BuildContext context, ErrorEvent error)? onError;
   Widget? onTokenErrorWidget;
   WebViewController? webViewController;

--- a/lib/flourish.dart
+++ b/lib/flourish.dart
@@ -42,6 +42,7 @@ class Flourish {
   late bool reloadPageOnAppResume;
   void Function(BuildContext context, WebResourceError error)? onWebViewLoadError;
   void Function(BuildContext context)? onAuthError;
+  void Function(BuildContext context, ErrorEvent error)? onError;
   Widget? onTokenErrorWidget;
   WebViewController? webViewController;
   String token = '';
@@ -58,6 +59,7 @@ class Flourish {
     required bool reloadPageOnAppResume,
     void Function(BuildContext context, WebResourceError error)? onWebViewLoadError,
     void Function(BuildContext context)? onAuthError,
+    void Function(BuildContext context, ErrorEvent error)? onError,
     Widget? onTokenErrorWidget,
   }) {
     this.uuid = uuid;
@@ -72,6 +74,7 @@ class Flourish {
     this.reloadPageOnAppResume = reloadPageOnAppResume;
     this.onWebViewLoadError = onWebViewLoadError;
     this.onAuthError = onAuthError;
+    this.onError = onError;
     this.onTokenErrorWidget = onTokenErrorWidget;
   }
 
@@ -84,6 +87,7 @@ class Flourish {
     bool reloadPageOnAppResume = true,
     void Function(BuildContext context, WebResourceError error)? onWebViewLoadError,
     void Function(BuildContext context)? onAuthError,
+    void Function(BuildContext context, ErrorEvent error)? onError,
     Widget? onTokenErrorWidget,
     String? version,
     String? trackingId,
@@ -99,6 +103,7 @@ class Flourish {
       reloadPageOnAppResume: reloadPageOnAppResume,
       onWebViewLoadError: onWebViewLoadError,
       onAuthError: onAuthError,
+      onError: onError,
       onTokenErrorWidget: onTokenErrorWidget,
     );
 
@@ -144,12 +149,31 @@ class Flourish {
     }
   }
 
+  /// Listens to ALL events dispatched by the SDK.
+  ///
+  /// Useful for centralized logging in production:
+  /// ```dart
+  /// flourish.onAllEvent((Event event) {
+  ///   developer.log('Event: ${event.name}', name: 'MyApp');
+  /// });
+  /// ```
   StreamSubscription<Event> onAllEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       callback(e);
     });
   }
 
+  /// Listens to unmapped events (events without a dedicated listener).
+  ///
+  /// Captures new events from the web app without requiring an SDK update.
+  /// Also receives [Event.ERROR_BACK_BUTTON_PRESSED] when the user
+  /// presses back on an error page.
+  ///
+  /// ```dart
+  /// flourish.onGenericEvent((GenericEvent event) {
+  ///   developer.log('${event.name} - data: ${jsonEncode(event.data?.toJson())}', name: 'MyApp');
+  /// });
+  /// ```
   StreamSubscription<Event> onGenericEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is GenericEvent) {
@@ -158,6 +182,7 @@ class Flourish {
     });
   }
 
+  /// Fires when the WebView finishes loading the Flourish web app.
   StreamSubscription<Event> onWebViewLoadedEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is WebViewLoadedEvent) {
@@ -166,6 +191,7 @@ class Flourish {
     });
   }
 
+  /// Fires when the user navigates to auto-payment setup.
   StreamSubscription<Event> onAutoPaymentEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is AutoPaymentEvent) {
@@ -174,6 +200,7 @@ class Flourish {
     });
   }
 
+  /// Fires when the user navigates to payment.
   StreamSubscription<Event> onPaymentEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is PaymentEvent) {
@@ -182,6 +209,9 @@ class Flourish {
     });
   }
 
+  /// Fires when a Trivia game finishes (legacy v1 event).
+  ///
+  /// Prefer [onTriviaGameFinishedEvent] for the v2 event with structured data.
   StreamSubscription<Event> onTriviaFinishedEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is TriviaFinishedEvent) {
@@ -190,6 +220,9 @@ class Flourish {
     });
   }
 
+  /// Fires when the user presses the back button (legacy v1 event).
+  ///
+  /// Prefer [onBackButtonPressedEvent] for the v2 event with structured data.
   StreamSubscription<Event> onBackEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is BackEvent) {
@@ -198,6 +231,15 @@ class Flourish {
     });
   }
 
+  /// Fires when the user presses the back menu button on the platform.
+  ///
+  /// Event: [Event.BACK_BUTTON_PRESSED]
+  ///
+  /// ```dart
+  /// flourish.onBackButtonPressedEvent((BackButtonPressedEvent event) {
+  ///   developer.log('${event.name} - data: ${jsonEncode(event.data.toJson())}', name: 'MyApp');
+  /// });
+  /// ```
   StreamSubscription<Event> onBackButtonPressedEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is BackButtonPressedEvent) {
@@ -206,6 +248,15 @@ class Flourish {
     });
   }
 
+  /// Fires when the user finishes a Trivia game.
+  ///
+  /// Event: [Event.TRIVIA_GAME_FINISHED]
+  ///
+  /// ```dart
+  /// flourish.onTriviaGameFinishedEvent((TriviaGameFinishedEvent event) {
+  ///   developer.log('${event.name} - data: ${jsonEncode(event.data.toJson())}', name: 'MyApp');
+  /// });
+  /// ```
   StreamSubscription<Event> onTriviaGameFinishedEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is TriviaGameFinishedEvent) {
@@ -214,6 +265,9 @@ class Flourish {
     });
   }
 
+  /// Fires when the user closes the Trivia game.
+  ///
+  /// Event: [Event.TRIVIA_CLOSED]
   StreamSubscription<Event> onTriviaCloseEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is TriviaCloseEvent) {
@@ -222,6 +276,9 @@ class Flourish {
     });
   }
 
+  /// Fires when the user copies the referral code.
+  ///
+  /// Event: [Event.REFERRAL_COPY]
   StreamSubscription<Event> onReferralCopyEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is ReferralCopyEvent) {
@@ -230,6 +287,9 @@ class Flourish {
     });
   }
 
+  /// Fires when the user copies the Gift Card code.
+  ///
+  /// Event: [Event.GIFT_CARD_COPY]
   StreamSubscription<Event> onGiftCardCopyEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is GiftCardCopyEvent) {
@@ -238,6 +298,9 @@ class Flourish {
     });
   }
 
+  /// Fires when the user clicks on the home banner.
+  ///
+  /// Event: [Event.HOME_BANNER_ACTION]
   StreamSubscription<Event> onHomeBannerActionEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is HomeBannerActionEvent) {
@@ -246,6 +309,9 @@ class Flourish {
     });
   }
 
+  /// Fires when the user clicks on a mission card.
+  ///
+  /// Event: [Event.MISSION_ACTION]
   StreamSubscription<Event> onMissionActionEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is MissionActionEvent) {
@@ -254,6 +320,25 @@ class Flourish {
     });
   }
 
+  /// Listens to ERROR events from the web app (network, business logic,
+  /// onboarding, maintenance errors).
+  ///
+  /// Event: [Event.ERROR]. The [ErrorEvent] contains [ErrorEvent.code]
+  /// and [ErrorEvent.message] with error details.
+  ///
+  /// For production logging, use `dart:developer` `log()`:
+  /// ```dart
+  /// flourish.onErrorEvent((ErrorEvent event) {
+  ///   developer.log(
+  ///     'Error: ${event.code} - ${event.message}',
+  ///     name: 'MyApp',
+  ///     level: 1000,
+  ///   );
+  /// });
+  /// ```
+  ///
+  /// **Note:** You can also handle errors via the [onError] callback in
+  /// [Flourish.create] which provides a [BuildContext] for navigation.
   StreamSubscription<Event> onErrorEvent(Function callback) {
     return this.onEvent.listen((Event e) {
       if (e is ErrorEvent) {

--- a/lib/network/api_service.dart
+++ b/lib/network/api_service.dart
@@ -1,8 +1,7 @@
-import 'dart:developer' as developer;
-
 import 'package:dio/dio.dart';
 import 'package:flourish_flutter_sdk/config/endpoint.dart';
 import 'package:flourish_flutter_sdk/config/environment_enum.dart';
+import 'package:flourish_flutter_sdk/utils/logger.dart';
 
 class ApiService {
   late final Dio httpClient;
@@ -50,7 +49,7 @@ class ApiService {
         },
       ),
     );
-    developer.log('Signed in successfully', name: 'FlourishSDK');
+    FlourishLog.info('Signed in successfully');
     return true;
   }
 }

--- a/lib/network/api_service.dart
+++ b/lib/network/api_service.dart
@@ -1,7 +1,8 @@
+import 'dart:developer' as developer;
+
 import 'package:dio/dio.dart';
 import 'package:flourish_flutter_sdk/config/endpoint.dart';
 import 'package:flourish_flutter_sdk/config/environment_enum.dart';
-import 'package:flutter/foundation.dart';
 
 class ApiService {
   late final Dio httpClient;
@@ -49,7 +50,7 @@ class ApiService {
         },
       ),
     );
-    if (kDebugMode) print("[flourish]: logged in");
+    developer.log('Signed in successfully', name: 'FlourishSDK');
     return true;
   }
 }

--- a/lib/utils/logger.dart
+++ b/lib/utils/logger.dart
@@ -1,0 +1,38 @@
+import 'dart:developer' as developer;
+
+/// Centralized logging for the Flourish SDK.
+///
+/// Wraps `dart:developer` `log()` with a consistent source name and severity
+/// levels, and redacts sensitive data before it reaches device/production logs.
+/// Filter by the `FlourishSDK` name in DevTools to see only SDK logs.
+class FlourishLog {
+  FlourishLog._();
+
+  static const String _name = 'FlourishSDK';
+
+  // dart:developer log levels (mirrors package:logging Level values).
+  static const int _infoLevel = 0;
+  static const int _warningLevel = 900;
+  static const int _severeLevel = 1000;
+
+  static void info(String message) =>
+      developer.log(message, name: _name, level: _infoLevel);
+
+  static void warning(String message) =>
+      developer.log(message, name: _name, level: _warningLevel);
+
+  static void severe(String message, {Object? error}) =>
+      developer.log(message, name: _name, level: _severeLevel, error: error);
+
+  /// Masks sensitive query params (e.g. the auth token) in a URI so it can be
+  /// logged without leaking secrets. Returns the URI as a string with the
+  /// `token`/`apiToken` values replaced by `[REDACTED]`.
+  static String redactUri(Uri uri) {
+    if (uri.queryParameters.isEmpty) return uri.toString();
+    final sanitized = Map<String, String>.from(uri.queryParameters);
+    for (final key in const ['token', 'apiToken']) {
+      if (sanitized.containsKey(key)) sanitized[key] = '[REDACTED]';
+    }
+    return uri.replace(queryParameters: sanitized).toString();
+  }
+}

--- a/lib/web_view/auth_error_page.dart
+++ b/lib/web_view/auth_error_page.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:developer' as developer;
 
 import 'package:flourish_flutter_sdk/flourish.dart';
+import 'package:flourish_flutter_sdk/utils/logger.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 
@@ -39,7 +39,7 @@ class AuthErrorPageState extends State<AuthErrorPage> {
         MaterialPageRoute(builder: (context) => widget.flourish.home()),
       );
     } catch (e) {
-      developer.log('Token refresh failed', name: 'FlourishSDK', error: e);
+      FlourishLog.severe('Token refresh failed', error: e);
     }
   }
 

--- a/lib/web_view/auth_error_page.dart
+++ b/lib/web_view/auth_error_page.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
+import 'dart:developer' as developer;
 
 import 'package:flourish_flutter_sdk/flourish.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 
@@ -39,7 +39,7 @@ class AuthErrorPageState extends State<AuthErrorPage> {
         MaterialPageRoute(builder: (context) => widget.flourish.home()),
       );
     } catch (e) {
-      if (kDebugMode) print(e);
+      developer.log('Token refresh failed', name: 'FlourishSDK', error: e);
     }
   }
 

--- a/lib/web_view/error_presentation.dart
+++ b/lib/web_view/error_presentation.dart
@@ -1,0 +1,30 @@
+/// How the SDK should surface an error to the user.
+///
+/// Decoupled from the widget so the decision can be unit-tested without a
+/// live [WebViewController] or [BuildContext].
+enum ErrorPresentation {
+  /// The widget is no longer mounted; do nothing.
+  none,
+
+  /// The integrator provided a callback; hand control over and suppress the
+  /// SDK's default navigation.
+  invokeCallback,
+
+  /// No callback provided; navigate to the SDK's fallback error page.
+  navigateToFallback,
+}
+
+/// Resolves how an error should be presented.
+///
+/// Shared by `handleAuthError` and `handleWebAppError` so both follow the same
+/// contract: a disposed widget short-circuits to [ErrorPresentation.none]; an
+/// integrator callback takes precedence over default navigation.
+ErrorPresentation resolveErrorPresentation({
+  required bool isMounted,
+  required bool hasCallback,
+}) {
+  if (!isMounted) return ErrorPresentation.none;
+  return hasCallback
+      ? ErrorPresentation.invokeCallback
+      : ErrorPresentation.navigateToFallback;
+}

--- a/lib/web_view/webview_container.dart
+++ b/lib/web_view/webview_container.dart
@@ -137,8 +137,18 @@ class WebviewContainerState extends State<WebviewContainer>
   }
 
   Future<void> _loadWebView(Uri uri) async {
-    developer.log('Loading URL: $uri', name: 'FlourishSDK');
+    developer.log('Loading URL: ${_redactToken(uri)}', name: 'FlourishSDK');
     return controller.loadRequest(uri);
+  }
+
+  /// Masks sensitive query params (e.g. the auth token) before logging a URL.
+  String _redactToken(Uri uri) {
+    if (uri.queryParameters.isEmpty) return uri.toString();
+    final sanitized = Map<String, String>.from(uri.queryParameters);
+    for (final key in const ['token', 'apiToken']) {
+      if (sanitized.containsKey(key)) sanitized[key] = '[REDACTED]';
+    }
+    return uri.replace(queryParameters: sanitized).toString();
   }
 
   @override
@@ -158,11 +168,10 @@ class WebviewContainerState extends State<WebviewContainer>
   }
 
   void _handleJavaScriptMessage(JavaScriptMessage message) {
-    developer.log('JS message received: ${message.message}', name: 'FlourishSDK');
-
     try {
       final json = jsonDecode(message.message);
       final eventName = json['eventName'];
+      developer.log('JS event received: $eventName', name: 'FlourishSDK');
 
       switch (eventName) {
         case "REFERRAL_COPY":

--- a/lib/web_view/webview_container.dart
+++ b/lib/web_view/webview_container.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer' as developer;
 
 import 'package:flourish_flutter_sdk/config/endpoint.dart';
 import 'package:flourish_flutter_sdk/config/environment_enum.dart';
@@ -9,7 +10,6 @@ import 'package:flourish_flutter_sdk/events/event_manager.dart';
 import 'package:flourish_flutter_sdk/flourish.dart';
 import 'package:flourish_flutter_sdk/web_view/auth_error_page.dart';
 import 'package:flourish_flutter_sdk/web_view/webview_load_error_page.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:share_plus/share_plus.dart';
@@ -137,7 +137,7 @@ class WebviewContainerState extends State<WebviewContainer>
   }
 
   Future<void> _loadWebView(Uri uri) async {
-    if (kDebugMode) print(uri.toString());
+    developer.log('Loading URL: $uri', name: 'FlourishSDK');
     return controller.loadRequest(uri);
   }
 
@@ -158,7 +158,7 @@ class WebviewContainerState extends State<WebviewContainer>
   }
 
   void _handleJavaScriptMessage(JavaScriptMessage message) {
-    if (kDebugMode) print(message.message);
+    developer.log('JS message received: ${message.message}', name: 'FlourishSDK');
 
     try {
       final json = jsonDecode(message.message);
@@ -171,17 +171,23 @@ class WebviewContainerState extends State<WebviewContainer>
         case "INVALID_TOKEN":
           unawaited(handleAuthError());
           break;
+        case "ERROR":
+          unawaited(handleWebAppError(json));
+          break;
         default:
           _handleGenericEvent(json);
       }
     } catch (e) {
-      if (kDebugMode) print('Error handling JS message: $e');
+      developer.log('Error handling JS message', name: 'FlourishSDK', error: e);
     }
   }
 
   Future<void> _handleReferralCopy(dynamic data) async {
     final referralCode = data['referralCode'];
-    if (referralCode == null) return print('referralCode is empty');
+    if (referralCode == null) {
+      developer.log('referralCode is empty', name: 'FlourishSDK', level: 900);
+      return;
+    }
     await Clipboard.setData(ClipboardData(text: referralCode));
     await Share.share(referralCode);
   }
@@ -196,8 +202,11 @@ class WebviewContainerState extends State<WebviewContainer>
   }
 
   Future<void> handleAuthError() async {
+    if (!mounted) return;
+
     final onAuthError = flourish.onAuthError;
     if (onAuthError != null) return onAuthError(context);
+
     await Navigator.pushReplacement(
       context,
       MaterialPageRoute(
@@ -206,30 +215,66 @@ class WebviewContainerState extends State<WebviewContainer>
     );
   }
 
+  Future<void> handleWebAppError(Map<String, dynamic> json) async {
+    final errorEvent = ErrorEvent.fromJson(json);
+    _notify(errorEvent);
+
+    if (!mounted) return;
+
+    final onError = flourish.onError;
+    if (onError != null) return onError(context, errorEvent);
+
+    await Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (context) => FlourishTokenErrorPage(flourish: flourish),
+      ),
+    );
+  }
+
   Future<dynamic> handleLoadingPageError(WebResourceError error) async {
+    developer.log(
+      'WebView Load Error - code: ${error.errorCode}, '
+      'type: ${error.errorType}, '
+      'description: ${error.description}, '
+      'isForMainFrame: ${error.isForMainFrame}',
+      name: 'FlourishSDK',
+      level: 1000,
+    );
+
     if (error.errorCode == 403) {
       if (mounted) {
-        Navigator.pushReplacement(
+        return Navigator.pushReplacement(
           context,
           MaterialPageRoute(
             builder: (context) => FlourishTokenErrorPage(flourish: flourish),
           ),
         );
       }
+      return;
     }
+
     if (error.errorType == WebResourceErrorType.connect ||
         error.errorType == WebResourceErrorType.timeout ||
         error.errorType == WebResourceErrorType.hostLookup ||
         error.errorCode == -1009) {
+      developer.log(
+        'Network connectivity error detected - invoking error handler',
+        name: 'FlourishSDK',
+        level: 900,
+      );
+
       final onWebViewLoadError = flourish.onWebViewLoadError;
       if (onWebViewLoadError != null) return onWebViewLoadError(context, error);
 
-      return Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(
-          builder: (context) => WebViewLoadErrorPage(flourish: flourish),
-        ),
-      );
+      if (mounted) {
+        return Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (context) => WebViewLoadErrorPage(flourish: flourish),
+          ),
+        );
+      }
     }
   }
 }

--- a/lib/web_view/webview_container.dart
+++ b/lib/web_view/webview_container.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:developer' as developer;
 
 import 'package:flourish_flutter_sdk/config/endpoint.dart';
 import 'package:flourish_flutter_sdk/config/environment_enum.dart';
@@ -8,7 +7,9 @@ import 'package:flourish_flutter_sdk/config/language.dart';
 import 'package:flourish_flutter_sdk/events/event.dart';
 import 'package:flourish_flutter_sdk/events/event_manager.dart';
 import 'package:flourish_flutter_sdk/flourish.dart';
+import 'package:flourish_flutter_sdk/utils/logger.dart';
 import 'package:flourish_flutter_sdk/web_view/auth_error_page.dart';
+import 'package:flourish_flutter_sdk/web_view/error_presentation.dart';
 import 'package:flourish_flutter_sdk/web_view/webview_load_error_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -97,14 +98,7 @@ class WebviewContainerState extends State<WebviewContainer>
 
             if (statusCode == 403 &&
                 content.contains('AccessDenied')) {
-              if (mounted) {
-                await Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => FlourishTokenErrorPage(flourish: flourish),
-                  ),
-                );
-              }
+              await _replaceWithErrorPage(FlourishTokenErrorPage(flourish: flourish));
             }
           },
         ),
@@ -137,18 +131,20 @@ class WebviewContainerState extends State<WebviewContainer>
   }
 
   Future<void> _loadWebView(Uri uri) async {
-    developer.log('Loading URL: ${_redactToken(uri)}', name: 'FlourishSDK');
+    FlourishLog.info('Loading URL: ${FlourishLog.redactUri(uri)}');
     return controller.loadRequest(uri);
   }
 
-  /// Masks sensitive query params (e.g. the auth token) before logging a URL.
-  String _redactToken(Uri uri) {
-    if (uri.queryParameters.isEmpty) return uri.toString();
-    final sanitized = Map<String, String>.from(uri.queryParameters);
-    for (final key in const ['token', 'apiToken']) {
-      if (sanitized.containsKey(key)) sanitized[key] = '[REDACTED]';
-    }
-    return uri.replace(queryParameters: sanitized).toString();
+  /// Replaces the current route with [page], guarding against a disposed widget.
+  ///
+  /// Centralizes the `mounted` check + `pushReplacement` boilerplate shared by
+  /// every error-page navigation in this container.
+  Future<void> _replaceWithErrorPage(Widget page) async {
+    if (!mounted) return;
+    await Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (_) => page),
+    );
   }
 
   @override
@@ -171,7 +167,7 @@ class WebviewContainerState extends State<WebviewContainer>
     try {
       final json = jsonDecode(message.message);
       final eventName = json['eventName'];
-      developer.log('JS event received: $eventName', name: 'FlourishSDK');
+      FlourishLog.info('JS event received: $eventName');
 
       switch (eventName) {
         case "REFERRAL_COPY":
@@ -187,14 +183,14 @@ class WebviewContainerState extends State<WebviewContainer>
           _handleGenericEvent(json);
       }
     } catch (e) {
-      developer.log('Error handling JS message', name: 'FlourishSDK', error: e);
+      FlourishLog.severe('Error handling JS message', error: e);
     }
   }
 
   Future<void> _handleReferralCopy(dynamic data) async {
     final referralCode = data['referralCode'];
     if (referralCode == null) {
-      developer.log('referralCode is empty', name: 'FlourishSDK', level: 900);
+      FlourishLog.warning('referralCode is empty');
       return;
     }
     await Clipboard.setData(ClipboardData(text: referralCode));
@@ -210,80 +206,73 @@ class WebviewContainerState extends State<WebviewContainer>
     widget.eventManager.notify(event);
   }
 
+  /// Handles an `INVALID_TOKEN` (401) event from the web app.
+  ///
+  /// Contract: if [Flourish.onAuthError] is provided, the integrator takes over
+  /// the UI and the default navigation is suppressed. Otherwise the SDK shows
+  /// [AuthErrorPage]. (Auth failures are not emitted on the event stream.)
   Future<void> handleAuthError() async {
-    if (!mounted) return;
-
     final onAuthError = flourish.onAuthError;
-    if (onAuthError != null) return onAuthError(context);
-
-    await Navigator.pushReplacement(
-      context,
-      MaterialPageRoute(
-        builder: (context) => AuthErrorPage(flourish: flourish),
-      ),
-    );
+    switch (resolveErrorPresentation(
+        isMounted: mounted, hasCallback: onAuthError != null)) {
+      case ErrorPresentation.none:
+        return;
+      case ErrorPresentation.invokeCallback:
+        return onAuthError!(context);
+      case ErrorPresentation.navigateToFallback:
+        return _replaceWithErrorPage(AuthErrorPage(flourish: flourish));
+    }
   }
 
+  /// Handles an `ERROR` event from the web app (network, business logic,
+  /// onboarding, maintenance, etc.).
+  ///
+  /// Contract: the [ErrorEvent] is ALWAYS published on the event stream
+  /// ([Flourish.onErrorEvent]) for observers. Separately, if
+  /// [Flourish.onError] is provided, the integrator takes over the UI and the
+  /// default navigation is suppressed; otherwise the SDK falls back to
+  /// [FlourishTokenErrorPage], which renders a generic "something went wrong /
+  /// contact support" screen (despite its name, it is not auth-specific).
   Future<void> handleWebAppError(Map<String, dynamic> json) async {
     final errorEvent = ErrorEvent.fromJson(json);
     _notify(errorEvent);
 
-    if (!mounted) return;
-
     final onError = flourish.onError;
-    if (onError != null) return onError(context, errorEvent);
-
-    await Navigator.pushReplacement(
-      context,
-      MaterialPageRoute(
-        builder: (context) => FlourishTokenErrorPage(flourish: flourish),
-      ),
-    );
+    switch (resolveErrorPresentation(
+        isMounted: mounted, hasCallback: onError != null)) {
+      case ErrorPresentation.none:
+        return;
+      case ErrorPresentation.invokeCallback:
+        return onError!(context, errorEvent);
+      case ErrorPresentation.navigateToFallback:
+        return _replaceWithErrorPage(FlourishTokenErrorPage(flourish: flourish));
+    }
   }
 
   Future<dynamic> handleLoadingPageError(WebResourceError error) async {
-    developer.log(
+    FlourishLog.severe(
       'WebView Load Error - code: ${error.errorCode}, '
       'type: ${error.errorType}, '
       'description: ${error.description}, '
       'isForMainFrame: ${error.isForMainFrame}',
-      name: 'FlourishSDK',
-      level: 1000,
     );
 
     if (error.errorCode == 403) {
-      if (mounted) {
-        return Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(
-            builder: (context) => FlourishTokenErrorPage(flourish: flourish),
-          ),
-        );
-      }
-      return;
+      return _replaceWithErrorPage(FlourishTokenErrorPage(flourish: flourish));
     }
 
     if (error.errorType == WebResourceErrorType.connect ||
         error.errorType == WebResourceErrorType.timeout ||
         error.errorType == WebResourceErrorType.hostLookup ||
         error.errorCode == -1009) {
-      developer.log(
+      FlourishLog.warning(
         'Network connectivity error detected - invoking error handler',
-        name: 'FlourishSDK',
-        level: 900,
       );
 
       final onWebViewLoadError = flourish.onWebViewLoadError;
       if (onWebViewLoadError != null) return onWebViewLoadError(context, error);
 
-      if (mounted) {
-        return Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(
-            builder: (context) => WebViewLoadErrorPage(flourish: flourish),
-          ),
-        );
-      }
+      return _replaceWithErrorPage(WebViewLoadErrorPage(flourish: flourish));
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -132,26 +132,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.1"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
@@ -345,10 +345,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -433,10 +433,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -502,5 +502,5 @@ packages:
     source: hosted
     version: "1.0.4"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flourish_flutter_sdk
 description: Flourish SDK for partners integrate.
-version: 3.1.0
+version: 3.2.0
 homepage: https://github.com/Flourish-savings/flourish-sdk-flutter
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flourish_flutter_sdk
 description: Flourish SDK for partners integrate.
-version: 3.2.0
+version: 4.0.0
 homepage: https://github.com/Flourish-savings/flourish-sdk-flutter
 
 environment:

--- a/test/events/error_event_test.dart
+++ b/test/events/error_event_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flourish_flutter_sdk/events/event.dart';
+import 'package:flourish_flutter_sdk/events/types/generic_event.dart';
+
+void main() {
+  group('ErrorEvent.fromJson', () {
+    test('parses code and message from data', () {
+      final event = ErrorEvent.fromJson({
+        'eventName': 'ERROR',
+        'data': {'code': 'NETWORK_ERROR', 'message': 'No connection'},
+      });
+      expect(event.code, 'NETWORK_ERROR');
+      expect(event.message, 'No connection');
+      expect(event.name, Event.ERROR);
+    });
+
+    test('defaults code to UNKNOWN_ERROR when code missing', () {
+      final event = ErrorEvent.fromJson({'eventName': 'ERROR', 'data': {}});
+      expect(event.code, 'UNKNOWN_ERROR');
+      expect(event.message, isNull);
+    });
+
+    test('falls back to empty data when data key is absent', () {
+      final event = ErrorEvent.fromJson({'eventName': 'ERROR'});
+      expect(event.code, 'UNKNOWN_ERROR');
+      expect(event.message, isNull);
+    });
+
+    test('falls back to empty data when data is not a map', () {
+      final event = ErrorEvent.fromJson({'eventName': 'ERROR', 'data': 'oops'});
+      expect(event.code, 'UNKNOWN_ERROR');
+      expect(event.message, isNull);
+    });
+
+    test('coerces non-string code and message to string', () {
+      final event = ErrorEvent.fromJson({
+        'eventName': 'ERROR',
+        'data': {'code': 500, 'message': 42},
+      });
+      expect(event.code, '500');
+      expect(event.message, '42');
+    });
+  });
+
+  group('Event.fromJson dispatch', () {
+    test('routes ERROR eventName to ErrorEvent', () {
+      final event = Event.fromJson({
+        'eventName': 'ERROR',
+        'data': {'code': 'X'},
+      });
+      expect(event, isA<ErrorEvent>());
+      expect(event.name, Event.ERROR);
+    });
+
+    test('routes unknown eventName to GenericEvent', () {
+      final event = Event.fromJson({'eventName': 'SOMETHING_NEW'});
+      expect(event, isA<GenericEvent>());
+    });
+  });
+}

--- a/test/utils/logger_test.dart
+++ b/test/utils/logger_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flourish_flutter_sdk/utils/logger.dart';
+
+void main() {
+  group('FlourishLog.redactUri', () {
+    test('redacts the token query param', () {
+      final uri = Uri.https('example.com', '/dashboard', {
+        'token': 'super-secret',
+        'lang': 'en',
+      });
+      final result = FlourishLog.redactUri(uri);
+      expect(result, contains('token=%5BREDACTED%5D'));
+      expect(result, isNot(contains('super-secret')));
+      expect(result, contains('lang=en'));
+    });
+
+    test('redacts the apiToken query param', () {
+      final uri = Uri.https('example.com', '/x', {'apiToken': 'abc123'});
+      final result = FlourishLog.redactUri(uri);
+      expect(result, isNot(contains('abc123')));
+    });
+
+    test('returns the URI unchanged when there are no query params', () {
+      final uri = Uri.https('example.com', '/dashboard');
+      expect(FlourishLog.redactUri(uri), uri.toString());
+    });
+
+    test('leaves non-sensitive params intact', () {
+      final uri = Uri.https('example.com', '/x', {'lang': 'pt', 'foo': 'bar'});
+      final result = FlourishLog.redactUri(uri);
+      expect(result, contains('lang=pt'));
+      expect(result, contains('foo=bar'));
+      expect(result, isNot(contains('REDACTED')));
+    });
+  });
+}

--- a/test/web_view/error_presentation_test.dart
+++ b/test/web_view/error_presentation_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flourish_flutter_sdk/web_view/error_presentation.dart';
+
+void main() {
+  group('resolveErrorPresentation', () {
+    test('returns none when the widget is not mounted', () {
+      expect(
+        resolveErrorPresentation(isMounted: false, hasCallback: true),
+        ErrorPresentation.none,
+      );
+      expect(
+        resolveErrorPresentation(isMounted: false, hasCallback: false),
+        ErrorPresentation.none,
+      );
+    });
+
+    test('invokes the callback when mounted and a callback is provided', () {
+      expect(
+        resolveErrorPresentation(isMounted: true, hasCallback: true),
+        ErrorPresentation.invokeCallback,
+      );
+    });
+
+    test('navigates to fallback when mounted and no callback is provided', () {
+      expect(
+        resolveErrorPresentation(isMounted: true, hasCallback: false),
+        ErrorPresentation.navigateToFallback,
+      );
+    });
+  });
+}


### PR DESCRIPTION
- Add onError callback in Flourish.create() for custom ERROR event handling
- Add ErrorEvent.fromJson factory and ERROR case in JS message handler
- Fix 403 error handler not returning early (could trigger both 403 and network handlers)
- Fix handleAuthError missing mounted check before using context
- Replace all print() calls with dart:developer log() for production-safe structured logging
- Add doc comments with production logging examples to all event listener methods
- Update README with Error Handling section, debug logging guide, and developer.log examples
- Add Spanish README (README.es.md)
- Bump version to 3.2.0